### PR TITLE
[JENKINS-35242] Fix library bundling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
   </scm>
   <properties>
     <jenkins.version>1.580.3</jenkins.version>
+    <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
     <java.level>6</java.level>
   </properties>
   <repositories>
@@ -72,12 +73,6 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jackson2-api</artifactId>
       <version>2.5.4</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>4.5</version>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
See [JENKINS-35242](https://issues.jenkins-ci.org/browse/JENKINS-35242)

After https://github.com/jenkinsci/aws-java-sdk-plugin/pull/3 , the hpi does not bundle `httpclient-4.3.6.jar` and `httpcore-4.3.3.jar` any more. It may be a problem in `maven-hpi-plugin` not correctly resolving the dependencies to bundle when one of them is overridden in the `test` scope (to be investigated).

A possible solution would be using the JTH from the baseline, but it breaks the PCT against 2.6 so as an interim solution, the injected tests (which are the ones demanding the conflicting dependency) are disabled. Being a pure wrapper plugin it should not be a big deal.

@reviewbybees (esp. @Vlatombe @ndeloof )