### PR TITLE
Update aws-java-sdk to 1.10.50.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <relativePath />
   </parent>
   <artifactId>aws-java-sdk</artifactId>
-  <version>1.10.45.3-SNAPSHOT</version>
+  <version>1.10.50-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>Amazon Web Services SDK</name>
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk</artifactId>
-      <version>1.10.45</version>
+      <version>1.10.50</version>
       <exclusions>
         <exclusion>
           <!-- Included in core -->


### PR DESCRIPTION
In pursuit of closing:
 * JENKINS-33196 - Add g2.8xlarge to the list of instance types
 * JENKINS-32600 - Move to 1.10.49 version of AWS SDK