### PR TITLE
update AWS SDK to 1.11.28

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <relativePath />
   </parent>
   <artifactId>aws-java-sdk</artifactId>
-  <version>1.10.51-SNAPSHOT</version>
+  <version>1.11.28-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>Amazon Web Services SDK</name>
@@ -31,7 +31,7 @@
   <scm>
     <connection>scm:git:git://github.com/jenkinsci/aws-java-sdk-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/aws-java-sdk-plugin.git</developerConnection>
-    <url>http://github.com/jenkinsci/aws-java-sdk-plugin</url>
+    <url>https://github.com/jenkinsci/aws-java-sdk-plugin</url>
     <tag>HEAD</tag>
   </scm>
   <properties>
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk</artifactId>
-      <version>1.10.50</version>
+      <version>1.11.28</version>
       <exclusions>
         <exclusion>
           <!-- Included in core -->


### PR DESCRIPTION
I'm hoping to use this latest version of the AWS SDK in another plugin, where I need access to IAM roles for ECS Tasks. Support for that wasn't added until 1.11.16.

This should resolve [JENKINS-36823](https://issues.jenkins-ci.org/browse/JENKINS-36823).