### PR TITLE
Bump to latest version of aws-sdk-java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <relativePath />
   </parent>
   <artifactId>aws-java-sdk</artifactId>
-  <version>1.11.38-SNAPSHOT</version>
+  <version>1.11.54-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>Amazon Web Services SDK</name>
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk</artifactId>
-      <version>1.11.37</version>
+      <version>1.11.54</version>
       <exclusions>
         <exclusion>
           <!-- Included in core -->


### PR DESCRIPTION
I'd like to be able to use m4.16xlarge instances that are available in the latest sdk.