### PR TITLE
Update parent pom and fix RequireUpperBoundDeps violations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.33</version>
+    <version>3.0</version>
     <relativePath />
   </parent>
   <artifactId>aws-java-sdk</artifactId>
@@ -35,9 +35,9 @@
     <tag>HEAD</tag>
   </scm>
   <properties>
-    <jenkins.version>1.580.3</jenkins.version>
+    <jenkins.version>1.625.1</jenkins.version>
     <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
-    <java.level>6</java.level>
+    <java.level>7</java.level>
   </properties>
   <repositories>
     <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.19</version>
+    <version>2.33</version>
     <relativePath />
   </parent>
   <artifactId>aws-java-sdk</artifactId>
@@ -67,12 +67,16 @@
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-databind</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jackson2-api</artifactId>
-      <version>2.5.4</version>
+      <version>2.7.0</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
This excludes jackson-core from the hpi as it was still included.