### PR TITLE
[maven-release-plugin] prepare release aws-java-sdk-1.11.341

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <relativePath />
   </parent>
   <artifactId>aws-java-sdk</artifactId>
-  <version>${revision}${changelist}</version>
+  <version>1.11.341</version>
   <packaging>hpi</packaging>
 
   <name>Amazon Web Services SDK</name>
@@ -32,7 +32,7 @@
     <connection>scm:git:git://github.com/jenkinsci/aws-java-sdk-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/aws-java-sdk-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/aws-java-sdk-plugin</url>
-    <tag>${scmTag}</tag>
+    <tag>aws-java-sdk-1.11.341</tag>
   </scm>
   <properties>
     <revision>1.11.329</revision>


### PR DESCRIPTION
Release new aws-java-sdk version to add new  EC2 instance types into API