### PR TITLE
AWS SDK 1.11.401

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <tag>${scmTag}</tag>
   </scm>
   <properties>
-    <revision>1.11.341</revision>
+    <revision>1.11.401</revision>
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>1.625.1</jenkins.version>
     <java.level>7</java.level>


### PR DESCRIPTION
I've updated to AWS SDK 1.11.401. In particular, this is necessary for the [EC2 plugin](https://github.com/jenkinsci/ec2-plugin) support the new T3 instance type.