### PR TITLE
Upgrade the sdk version to support newer instance types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ CHANGELOG
 See [full changelog](https://github.com/aws/aws-sdk-java/blob/master/CHANGELOG.md) from the library (use the first 3 digits).
 Below are listed changes others than the library itself.
 
+1.11.513
+--------
+* [aws-java-sdk changelog](https://github.com/aws/aws-sdk-java/blob/master/CHANGELOG.md#111513-2019-03-06)
+
 1.11.457
 --------
 * [aws-java-sdk changelog](https://github.com/aws/aws-sdk-java/blob/master/CHANGELOG.md#111457-2018-11-27)

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <tag>${scmTag}</tag>
   </scm>
   <properties>
-    <revision>1.11.458</revision>
+    <revision>1.11.513</revision>
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.60.3</jenkins.version>
     <java.level>8</java.level>


### PR DESCRIPTION
New instance types have been introduced, such as m5.metal, r5.metal, etc. 

I've moved it forward to the latest release, [instead of the release where the instances were introduced](https://github.com/aws/aws-sdk-java/blob/1.11.513/CHANGELOG.md#111499-2019-02-14), but I can move it less if you want a smaller difference in the release.

More info about the instances [here](https://aws.amazon.com/blogs/aws/now-available-five-new-amazon-ec2-bare-metal-instances-m5-m5d-r5-r5d-and-z1d/)

