### PR TITLE
Bump to 1.11.562

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ CHANGELOG
 See [full changelog](https://github.com/aws/aws-sdk-java/blob/master/CHANGELOG.md) from the library (use the first 3 digits).
 Below are listed changes others than the library itself.
 
+1.11.562
+--------
+* [aws-java-sdk changelog](https://github.com/aws/aws-sdk-java/blob/master/CHANGELOG.md#111562-2019-05-29)
+
 1.11.457
 --------
 * [aws-java-sdk changelog](https://github.com/aws/aws-sdk-java/blob/master/CHANGELOG.md#111457-2018-11-27)

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <tag>${scmTag}</tag>
   </scm>
   <properties>
-    <revision>1.11.458</revision>
+    <revision>1.11.562</revision>
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.60.3</jenkins.version>
     <java.level>8</java.level>


### PR DESCRIPTION
- Bump to a newer version so other plugins can use the new features like newer instances