### PR TITLE
Upgrade the sdk version to support newer instance types (I3en)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ CHANGELOG
 See [full changelog](https://github.com/aws/aws-sdk-java/blob/master/CHANGELOG.md) from the library (use the first 3 digits).
 Below are listed changes others than the library itself.
 
+1.11.594
+--------
+* [aws-java-sdk changelog](https://github.com/aws/aws-sdk-java/blob/master/CHANGELOG.md#111594-2019-07-18)
+
 1.11.562
 --------
 * [aws-java-sdk changelog](https://github.com/aws/aws-sdk-java/blob/master/CHANGELOG.md#111562-2019-05-29)

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <tag>${scmTag}</tag>
   </scm>
   <properties>
-    <revision>1.11.562</revision>
+    <revision>1.11.594</revision>
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.60.3</jenkins.version>
     <java.level>8</java.level>


### PR DESCRIPTION
New instance type has been introduced in 1.11.564 i.e.[I3en](https://github.com/aws/aws-sdk-java/blob/master/CHANGELOG.md#features-103). So just moving the aws-java-sdk to the latest release. 

More info about I3en [here](https://aws.amazon.com/ec2/instance-types/i3en/)