### PR TITLE
Release Drafter & Badges

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,3 @@
+_extends: .github
+tag-template: aws-java-sdk-$NEXT_PATCH_VERSION
+version-template: $MAJOR.$MINOR.$PATCH

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 CHANGELOG
 =========
 
-1.11.563 and newer
+1.11.594 and newer
 ------
 
 No longer tracked in this file. See [GitHub releases](https://github.com/jenkinsci/aws-java-sdk-plugin/releases) instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+1.11.563 and newer
+------
+
+No longer tracked in this file. See [GitHub releases](https://github.com/jenkinsci/aws-java-sdk-plugin/releases) instead.
+
 See [full changelog](https://github.com/aws/aws-sdk-java/blob/master/CHANGELOG.md) from the library (use the first 3 digits).
 Below are listed changes others than the library itself.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 This plugin provides the AWS SDK for Java as a library to be used by other plugins. It follows the same versioning as the AWS SDK itself.
 
 https://wiki.jenkins-ci.org/display/JENKINS/Amazon+Web+Services+SDK+library
+
+
+[![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/aws-java-sdk.svg)](https://plugins.jenkins.io/aws-java-sdk)
+[![GitHub release](https://img.shields.io/github/release/jenkinsci/aws-java-sdk.svg?label=release)](https://github.com/jenkinsci/aws-java-sdk-plugin/releases/latest)
+[![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/aws-java-sdk.svg?color=blue)](https://plugins.jenkins.io/aws-java-sdk)


### PR DESCRIPTION
Added Badges to the README and included Release Drafter

See [Usage](https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc#usage). 
Need to enable the app on the repo, I have tested on my fork. 

If you merge this, we then need to

- apply appropriate labels (like bug) to all PRs merged since 1.11.562

- do the 1.11.594  release pending Approval of [24 ](https://github.com/jenkinsci/aws-java-sdk-plugin/pull/24/files)

- start using it (first release will need more cleanup, to delete the old entries)