### PR TITLE
Update to 1.11.636

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <tag>${scmTag}</tag>
   </scm>
   <properties>
-    <revision>1.11.595</revision>
+    <revision>1.11.636</revision>
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.60.3</jenkins.version>
     <java.level>8</java.level>


### PR DESCRIPTION
Update aws java sdk to get access to G4 instances
https://aws.amazon.com/blogs/aws/now-available-ec2-instances-g4-with-nvidia-t4-tensor-core-gpus/
https://github.com/aws/aws-sdk-java/blob/master/CHANGELOG.md#111636-2019-09-20