### PR TITLE
Fix release badge not displaying due to incorrect URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ https://wiki.jenkins-ci.org/display/JENKINS/Amazon+Web+Services+SDK+library
 
 
 [![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/aws-java-sdk.svg)](https://plugins.jenkins.io/aws-java-sdk)
-[![GitHub release](https://img.shields.io/github/release/jenkinsci/aws-java-sdk.svg?label=release)](https://github.com/jenkinsci/aws-java-sdk-plugin/releases/latest)
+[![GitHub release](https://img.shields.io/github/v/release/jenkinsci/aws-java-sdk-plugin.svg?label=release)](https://github.com/jenkinsci/aws-java-sdk-plugin/releases/latest)
 [![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/aws-java-sdk.svg?color=blue)](https://plugins.jenkins.io/aws-java-sdk)


### PR DESCRIPTION
Updated URL for Release Badge as it was incorrect and displaying an error. 
