### PR TITLE
Update netty transitive dependency to 4.1.43

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,21 @@
       <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
+  <!-- TODO: remove netty dependency update after upstream aws-java-sdk fixes dependency on CVE-2019-16869 -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-http</artifactId>
+        <version>4.1.43.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler</artifactId>
+        <version>4.1.43.Final</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>com.amazonaws</groupId>


### PR DESCRIPTION
This addresses [CVE-2019-16869](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16869).

@jeffret-b @Wadeck @daniel-beck 