### PR TITLE
BEE-2296 Override netty version until AWS releases update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
     <java.level>8</java.level>
     <jackson.version>2.12.1</jackson.version>
     <jenkins.version>2.222.4</jenkins.version>
+    <netty.version>4.1.60.Final</netty.version>
   </properties>
   <repositories>
     <repository>
@@ -97,6 +98,16 @@
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-cbor</artifactId>
         <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-http</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler</artifactId>
+        <version>${netty.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Overrides netty version bundled with aws-java-sdk as the version 4.1.59.Final is vulnerable 
ref 
 https://github.com/netty/netty/security/advisories/GHSA-wm47-8v5p-wjpj 
 https://nvd.nist.gov/vuln/detail/CVE-2021-21295
 
 Once this is resolved the override should be removed. 
 https://github.com/aws/aws-sdk-java/issues/2531