### PR TITLE
fix dependency on aws logs

### DIFF
--- a/aws-java-sdk-logs/pom.xml
+++ b/aws-java-sdk-logs/pom.xml
@@ -20,7 +20,7 @@
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-iam</artifactId>
+      <artifactId>aws-java-sdk-logs</artifactId>
       <exclusions>
         <exclusion>
           <groupId>com.amazonaws</groupId>


### PR DESCRIPTION
Fix the wrong dependency on aws-java-sdk-iam instead of aws-java-sdk-logs
Looks like the logs module was first copied from iam and later some partial fixes were applied: https://github.com/jenkinsci/aws-java-sdk-plugin/commit/efd40a302a2f5aaeb6ac9e45a37d745e3093a1a4
Right now, installing jenkins plugin `"Amazon Web Services SDK :: Logs"` does not provide classes in aws-java-sdk-logs like `com.amazonaws.services.logs.AWSLogsClientBuilder`.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
