### PR TITLE
Fix markdown syntax, remove outdated reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ If you need to use an API that is not yet published as its own plugin, feel free
 
 * Create a new directory `aws-java-sdk-<name>`. The name should be identical to the aws sdk module.
 * Create `pom.xml`.
-** Depend on `com.amazonaws:aws-java-sdk-<name>`. Exclude all transitive dependencies.
-** Transitive dependencies should be replaced by their equivalent plugin dependency. Most APIs only depend on `aws-java-sdk-core` and `jmespath-java` (called `aws-java-sdk-jmespath` in this project for clarity in the Jenkins ecosystem).
+  * Depend on `com.amazonaws:aws-java-sdk-<name>`. Exclude all transitive dependencies.
+  * Transitive dependencies should be replaced by their equivalent plugin dependency. Most APIs only depend on `aws-java-sdk-core` and `jmespath-java` (both are part of the `aws-java-sdk-minimal` plugin).
 * Create `src/main/resource/index.jelly`. Look at existing modules and adapt it.
 * Add the module to the root `pom.xml`.
 * Add the plugin dependency to `aws-java-sdk` and exclude the module from transitive dependencies.


### PR DESCRIPTION
Fix markdown rendering + remove a reference to aws-java-sdk-jmespath plugin which no longer exists (at least in code).

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [n/a] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [n/a] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
