### PR TITLE
[JENKINS-68450] Prepare Amazon Web Services SDK :: Minimal for removal of JAXB and Java 11 requirement

### DIFF
--- a/aws-java-sdk-minimal/pom.xml
+++ b/aws-java-sdk-minimal/pom.xml
@@ -53,6 +53,11 @@
       <version>${revision}</version>
     </dependency>
     <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>jaxb</artifactId>
+      <version>2.3.0.1</version>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jackson2-api</artifactId>
     </dependency>

--- a/aws-java-sdk-minimal/src/test/java/com/amazonaws/util/Base64Test.java
+++ b/aws-java-sdk-minimal/src/test/java/com/amazonaws/util/Base64Test.java
@@ -1,0 +1,45 @@
+package com.amazonaws.util;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.binary.Hex;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.RealJenkinsRule;
+
+public class Base64Test {
+
+    private static final String sample1 = "mO4TyLWG7vjFWdKT8IJcVbZ/jwc=";
+    private static final byte[] sample1Bytes;
+    private static final String sample2 = "F4I4p8Vf/mS+Kxvri3FPoMcqmJ1f";
+    private static final byte[] sample2Bytes;
+    private static final String sample3 = "UJmEdJYodqHJmd7Rtv6/OP29/jUEFw==";
+    private static final byte[] sample3Bytes;
+
+    static {
+        try {
+            sample1Bytes = Hex.decodeHex("98ee13c8b586eef8c559d293f0825c55b67f8f07");
+            sample2Bytes = Hex.decodeHex("178238a7c55ffe64be2b1beb8b714fa0c72a989d5f");
+            sample3Bytes = Hex.decodeHex("50998474962876a1c999ded1b6febf38fdbdfe350417");
+        } catch (DecoderException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Rule public RealJenkinsRule rr = new RealJenkinsRule();
+
+    @Test
+    public void smokes() throws Throwable {
+        rr.then(Base64Test::_smokes);
+    }
+
+    private static void _smokes(JenkinsRule r) {
+        assertArrayEquals("1".getBytes(StandardCharsets.US_ASCII), Base64.decode("MQ=="));
+        assertArrayEquals(sample1Bytes, Base64.decode(sample1));
+        assertArrayEquals(sample2Bytes, Base64.decode(sample2));
+        assertArrayEquals(sample3Bytes, Base64.decode(sample3));
+    }
+}


### PR DESCRIPTION
See [JENKINS-68450](https://issues.jenkins.io/browse/JENKINS-68450). This plugin bundles `com/amazonaws/util/Base64`, which consumes JAXB. But when running on Java 9+, JAXB is not included on the classpath by default. The only way for a plugin to have access to JAXB when running on Jenkins 2.164 or later on Java 11 is to declare a plugin-to-plugin dependency on JAXB API plugin (recommended) or to embed JAXB into its .jpi file.

Yet this seemed to be working. How? I debugged this and realized that `aws-java-sdk-minimal` currently does have access to `jaxb`, but only by accident: because it depends on `jackson2-api` (which, as of the latest version, has a direct dependency on `jaxb`) and `apache-httpcomponents-client-4-api` (which has an implicit dependency on `jaxb`) by virtue of having an old core baseline from before `jaxb` was detached. We should not rely on either. When both of these dependencies are removed for debugging purposes, the following returns false:

```
def field = Jenkins.get().pluginManager.getPlugin('aws-java-sdk-minimal').classLoader.loadClass('com.amazonaws.util.Base64').getDeclaredField('isJaxbAvailable')
field.accessible = true
field.get(null)
```

With the changes in this PR, it now returns true as expected.

This PR also adds a `RealJenkinsRule` test. Although it didn't catch this problem to begin with for the reason described above, it at least ensures we won't regress in the future. CC @Vlatombe 