### PR TITLE
Move plugin description to index.jelly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,6 @@
   <packaging>pom</packaging>
 
   <name>Amazon Web Services SDK :: Parent</name>
-  <description>This plugin provides AWS SDK for Java for other plugins.</description>
   <url>https://github.com/jenkinsci/aws-java-sdk-plugin</url>
   <licenses>
     <license>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<div>
+    This plugin provides AWS SDK for Java for other plugins.
+</div>


### PR DESCRIPTION
According to the [Google Document](https://docs.google.com/document/d/1PKYIpPlRVGsBqrz0Ob1Cv3cefOZ5j2xtGZdWs27kLuw/edit#) provided , <strong >I have created the src/main/resources/index.jelly file </strong> and removed the description tag from the pom file as specified under the <strong> Move plugin description to index.jelly </strong> topic

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

