### PR TITLE
Upgrade plugin POM and BOM to latest versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.54</version>
+    <version>4.57</version>
     <relativePath />
   </parent>
   <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
@@ -76,7 +76,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${bom}</artifactId>
-        <version>1836.vfe602c266c05</version>
+        <version>1935.v530f4395930f</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
This is needed for the forthcoming PCT multi-module mode to pull in the fix for [JENKINS-62658](https://issues.jenkins.io/browse/JENKINS-62658) via https://github.com/jenkinsci/maven-hpi-plugin/pull/453. I tested this successfully with the latest update to the multimodule project branch of PCT, which is now doing `mvn process test-classes` rather than `mvn install`, therefore requiring the fix for [JENKINS-62658](https://issues.jenkins.io/browse/JENKINS-62658). With these changes you can now successfully run `mvn process-test-classes` in the root directory of the repository, which was not possible with the old version of Maven HPI plugin.

I also upgraded BOM while I was here, but that is not essential. Feel free to undo that change if it is not desired.

CC @Vlatombe 