### PR TITLE
Add aws-java-sdk-kinesis as separate module

### DIFF
--- a/aws-java-sdk-kinesis/pom.xml
+++ b/aws-java-sdk-kinesis/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
+    <artifactId>aws-java-sdk-parent</artifactId>
+    <version>${revision}-${changelist}</version>
+  </parent>
+  <artifactId>aws-java-sdk-kinesis</artifactId>
+  <packaging>hpi</packaging>
+
+  <name>Amazon Web Services SDK :: kinesis</name>
+  <url>https://github.com/jenkinsci/aws-java-sdk-plugin</url>
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>aws-java-sdk-minimal</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-kinesis</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.amazonaws</groupId>
+          <artifactId>aws-java-sdk-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.amazonaws</groupId>
+          <artifactId>jmespath-java</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+</project>

--- a/aws-java-sdk-kinesis/src/main/resources/index.jelly
+++ b/aws-java-sdk-kinesis/src/main/resources/index.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<div>
+  Kinesis module for the <a href="https://aws.amazon.com/sdk-for-java/">AWS SDK for Java</a>.
+</div>

--- a/aws-java-sdk/pom.xml
+++ b/aws-java-sdk/pom.xml
@@ -56,6 +56,11 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
+      <artifactId>aws-java-sdk-kinesis</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.aws-java-sdk</groupId>
       <artifactId>aws-java-sdk-logs</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -119,6 +124,10 @@
         <exclusion>
           <groupId>com.amazonaws</groupId>
           <artifactId>aws-java-sdk-iam</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.amazonaws</groupId>
+          <artifactId>aws-java-sdk-kinesis</artifactId>
         </exclusion>
         <exclusion>
           <groupId>com.amazonaws</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
     <module>aws-java-sdk-efs</module>
     <module>aws-java-sdk-elasticbeanstalk</module>
     <module>aws-java-sdk-iam</module>
+    <module>aws-java-sdk-kinesis</module>
     <module>aws-java-sdk-logs</module>
     <module>aws-java-sdk-minimal</module>
     <module>aws-java-sdk-sns</module>


### PR DESCRIPTION
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

This PR splits out the aws-java-sdk-kinesis as a separate module for use in Jenkins plugins. The base com.amazonaws:aws-java-sdk-kinesis module doesn't have any transitive dependencies not already handled by aws-java-sdk-minimal. I was able to implement this by following @Vlatombe 's implementation of the efs module (see #796).

This is intended to reduce the scope of required dependencies for Jenkins plugins to publish and consume data from Kinesis streams.