### PR TITLE
Rely on BOM to provide jackson2-api version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,6 @@
   <properties>
     <revision>1.12.671</revision>
     <changelist>999999-SNAPSHOT</changelist>
-    <jackson.version>2.16.2-378.v7e79818f53ce</jackson.version>
     <bom>2.401.x</bom>
     <jenkins.version>2.401.3</jenkins.version>
     <autoVersionSubmodules>true</autoVersionSubmodules>
@@ -114,11 +113,6 @@
             <artifactId>httpclient</artifactId>
           </exclusion>
         </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>jackson2-api</artifactId>
-        <version>${jackson.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
https://github.com/jenkinsci/aws-java-sdk-plugin/pull/1231#discussion_r1536009659

With current version of BOM, this rolls back requirement of jackson2-api to 2.16.1, but it doesn't really matter.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
